### PR TITLE
model: Cinderella Girls / U149の楽曲を追加する

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -4,6 +4,7 @@ import {
   getAlbum,
   getAllAlbums,
   getAllStarsAlbums,
+  getCinderellaGirlsAlbums,
   getFiveStarsAlbum,
   getMillionLiveAlbums,
   getShinyColorsAlbums,
@@ -20,6 +21,9 @@ app.get("/album", (c) => {
 });
 app.get("/album/allstars", (c) => {
   return c.json(getAllStarsAlbums());
+});
+app.get("/album/cinderellagirls", (c) => {
+  return c.json(getCinderellaGirlsAlbums());
 });
 app.get("/album/millionlive", (c) => {
   return c.json(getMillionLiveAlbums());

--- a/src/controllers/api.ts
+++ b/src/controllers/api.ts
@@ -1,13 +1,15 @@
 import AllStars from "../model/AllStars.ts";
-import ShinyColors from "../model/ShinyColors.ts";
-import MillionLive from "../model/MillionLive.ts";
 import FiveStars from "../model/FiveStars.ts";
+import CinderellaGirls from "../model/CinderellaGirls.ts";
+import MillionLive from "../model/MillionLive.ts";
+import ShinyColors from "../model/ShinyColors.ts";
 import SideM from "../model/SideM.ts";
 import { Album } from "../types/Album.ts";
 
 const albums: Array<Album> = [];
 const allAlbums: Array<Album> = albums.concat(
   AllStars,
+  CinderellaGirls,
   MillionLive,
   ShinyColors,
   FiveStars,
@@ -24,6 +26,10 @@ const isMissing = (value: Album | undefined) => {
 
 export const getAllStarsAlbums = () => {
   return { msg: "Data fetched.", data: AllStars };
+};
+
+export const getCinderellaGirlsAlbums = () => {
+  return { msg: "Data fetched.", data: CinderellaGirls };
 };
 
 export const getMillionLiveAlbums = () => {

--- a/src/model/CinderellaGirls.ts
+++ b/src/model/CinderellaGirls.ts
@@ -1,0 +1,8 @@
+import { Album } from "../types/Album.ts";
+import U149 from "./cinderellagirls/U149.ts";
+
+const Albums: Array<Album> = [];
+
+const CinderellaGirls = Albums.concat(U149);
+
+export default CinderellaGirls;

--- a/src/model/cinderellagirls/U149.ts
+++ b/src/model/cinderellagirls/U149.ts
@@ -14,6 +14,9 @@ const U149: Array<Album> = [
       applemusic: "1682153879",
       amazon: "B0C2BW842R",
     },
+    songs: [
+      "Shine In The Sky☆",
+    ],
   },
 ];
 

--- a/src/model/cinderellagirls/U149.ts
+++ b/src/model/cinderellagirls/U149.ts
@@ -1,0 +1,20 @@
+import { Album } from "../../types/Album.ts";
+
+const U149: Array<Album> = [
+  /* U149 ANIMATION MASTER */
+  {
+    id: "cocc-18121",
+    name:
+      "THE IDOLM@STER CINDERELLA GIRLS U149 ANIMATION MASTER 01 Shine In The Sky☆",
+    brand: "cinderellagirls",
+    series: "THE IDOLM@STER CINDERELLA GIRLS U149 ANIMATION MASTER",
+    cover: "https://columbia.jp/idolmaster/imasnews/images/COCC-18121L.jpg",
+    platform: {
+      spotify: "6N9ubCUVfhpFH3abRDbL0y",
+      applemusic: "1682153879",
+      amazon: "B0C2BW842R",
+    },
+  },
+];
+
+export default U149;


### PR DESCRIPTION
4月14日未明に、U149アニメ楽曲のフルコーラス版の先行配信が開始されました( https://twitter.com/u149_anime/status/1646531185114324993 )。  
日本コロムビアがアイドルマスターの新譜フルコーラスを配信に乗せることは初の試みであり、不透明な点が多いため様子見をしながら追加します。

- 「Shine In The Sky☆」が主題歌であることから特例として扱われているのか、それともU149アニメの楽曲がすべてフルコーラスで乗るのか
- CDが発売されたら取り下げられたりしないか
- 今後もCDより先に配信がはじまるのか
- ショート尺のものがある程度纏められてアルバムとして扱われているが、そちらをまとめるべきか
  - 全曲プレイリストは配信楽曲の増加に伴い肥大化しており、検索性に難があります 